### PR TITLE
Add env vars for github client id and secret.

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -4,8 +4,10 @@ play.http.session.cookie.secure=true
 play.editor="http://localhost:63342/api/file/?file=%s&line=%s"
 
 # env vars for github auth
-github.client.id="<client_id>"
-github.client.secret="<client_secret>"
+github.client.id="<client-id>"
+github.client.id=${?GITHUB_CLIENT_ID_TEAHUB}
+github.client.secret="<client-secret>"
+github.client.secret=${?GITHUB_CLIENT_SECRET_TEAHUB}
 github.client.scope="repo"
 github.oauth.url="https://github.com/login/oauth/authorize?client_id=%s&redirect_uri=%s&scope=%s&state=%s"
 github.redirect.url="http://localhost:9000/callback"


### PR DESCRIPTION
User has to define the below enviroment variables.
(Data can be found in https://github.com/settings/developers.)
- GITHUB_CLIENT_ID_TEAHUB=""
- GITHUB_CLIENT_SECRET_TEAHUB=""