### PR TITLE
Fix wsClient and warning for /GET when listing projects.

### DIFF
--- a/app/AppLoader.scala
+++ b/app/AppLoader.scala
@@ -1,25 +1,25 @@
 import com.typesafe.config.Config
-import controllers.{OAuthGitHubController, TEAHubController, UIController}
-import play.api.{Application, ApplicationLoader, BuiltInComponentsFromContext, LoggerConfigurator}
+import controllers.{ OAuthGitHubController, TEAHubController, UIController }
+import play.api.{ Application, ApplicationLoader, BuiltInComponentsFromContext, LoggerConfigurator }
 import play.api.ApplicationLoader.Context
 import play.api.cache.EhCacheComponents
 import play.api.libs.ws.ahc.AhcWSClient
 import play.api.i18n._
-import services.impl.{ApiGitHubService, ApiOAuthGitHubService, ApiTogglService}
-import scala.concurrent.{ExecutionContext, Future}
+import services.impl.{ ApiGitHubService, ApiOAuthGitHubService, ApiTogglService }
+import scala.concurrent.{ ExecutionContext, Future }
 import router.Routes
 
 /**
-  * Instantiates all parts of the application and wires everything together.
-  */
+ * Instantiates all parts of the application and wires everything together.
+ */
 class AppLoader extends ApplicationLoader {
 
   /**
-    * Loads the application given the context
-    * @param context is the context for loading an application (includes Environment, initial configuration, web
-    *                command handler and optional source mapper
-    * @return the created application
-    */
+   * Loads the application given the context
+   * @param context is the context for loading an application (includes Environment, initial configuration, web
+   *                command handler and optional source mapper
+   * @return the created application
+   */
   override def load(context: Context): Application = {
     implicit val ec: ExecutionContext = play.api.libs.concurrent.Execution.defaultContext
 
@@ -31,12 +31,12 @@ class AppLoader extends ApplicationLoader {
 }
 
 /**
-  * Provides all the built in components dependencies from the application loader context
-  * @param context is the context for loading an application.
-  * @param ec implicit execution context for asynchronous execution of program logic
-  */
+ * Provides all the built in components dependencies from the application loader context
+ * @param context is the context for loading an application.
+ * @param ec implicit execution context for asynchronous execution of program logic
+ */
 class AppComponent(context: Context)(implicit val ec: ExecutionContext) extends BuiltInComponentsFromContext(context)
-  with EhCacheComponents with I18nComponents {
+    with EhCacheComponents with I18nComponents {
 
   val config: Config = context.initialConfiguration.underlying
   val wsClient = AhcWSClient()

--- a/app/controllers/OAuthGitHubController.scala
+++ b/app/controllers/OAuthGitHubController.scala
@@ -2,36 +2,34 @@ package controllers
 
 import play.api.mvc._
 import services.impl.ApiOAuthGitHubService
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 import routes.TEAHubController
 
 /**
-  * This is the controller responsible for the actions related to OAuth authentication between TEAHub and GitHub.
-  * @param oauthGitHubService helper service for authentication
-  * @param executionContext the execution context for asynchronous execution of program logic
-  */
-class OAuthGitHubController(oauthGitHubService: ApiOAuthGitHubService)
-                           (implicit executionContext: ExecutionContext) extends Controller {
+ * This is the controller responsible for the actions related to OAuth authentication between TEAHub and GitHub.
+ * @param oauthGitHubService helper service for authentication
+ * @param executionContext the execution context for asynchronous execution of program logic
+ */
+class OAuthGitHubController(oauthGitHubService: ApiOAuthGitHubService)(implicit executionContext: ExecutionContext) extends Controller {
 
   /**
-    * Make the initial request to authenticate via GitHub with OAuth protocol. The response will be sent to the
-    * `redirect_url` and will be handled by the [[callback()]] function
-    * @return Renders the login page and creates a session with the `oauth-state` in it.
-    */
+   * Make the initial request to authenticate via GitHub with OAuth protocol. The response will be sent to the
+   * `redirect_url` and will be handled by the [[callback()]] function
+   * @return Renders the login page and creates a session with the `oauth-state` in it.
+   */
   def login = Action.async { implicit request =>
     val (connectURL, state) = oauthGitHubService.oauthGitHubConnectUrl
     Future.successful(Ok(views.html.index("Log-in to TEAHub", connectURL)).
-      withSession("oauth-state" -> state)
-    )
+      withSession("oauth-state" -> state))
   }
 
   /**
-    * The URL in our application where users will be sent after authorization will trigger this action. In the URL the
-    * code and state parameters are filled in by GitHub.
-    * @param codeOpt is the code received when requesting access to GitHub.
-    * @param stateOpt an unguessable random string. It is used to protect against cross-site request forgery attacks.
-    * @return The list of GitHub repositories if the authentication was successful.
-    */
+   * The URL in our application where users will be sent after authorization will trigger this action. In the URL the
+   * code and state parameters are filled in by GitHub.
+   * @param codeOpt is the code received when requesting access to GitHub.
+   * @param stateOpt an unguessable random string. It is used to protect against cross-site request forgery attacks.
+   * @return The list of GitHub repositories if the authentication was successful.
+   */
   def callback(codeOpt: Option[String] = None, stateOpt: Option[String] = None) = Action.async { implicit request =>
     (for {
       code <- codeOpt
@@ -44,21 +42,19 @@ class OAuthGitHubController(oauthGitHubService: ApiOAuthGitHubService)
         }.recover {
           case ex: IllegalStateException => Unauthorized(ex.getMessage)
         }
-      }
-      else {
+      } else {
         Future.successful(BadRequest("Invalid github login"))
       }
     }).getOrElse(Future.successful(Redirect(controllers.routes.OAuthGitHubController.login))) // when using back button from /main to /callback we are sent to login page
   }
 
   /**
-    * If authentication was successful returns the projects in GitHub.
-    * @return A json object containing the list of GitHub repositories.
-    */
+   * If authentication was successful returns the projects in GitHub.
+   * @return A json object containing the list of GitHub repositories.
+   */
   def success() = Action.async { request =>
     request.session.get("oauth-token").fold(Future.successful(Unauthorized("401 Authentication token not found!"))) { authToken =>
-      Future(Redirect(TEAHubController.githubRepositories())
-      )
+      Future(Redirect(TEAHubController.githubRepositories()))
     }
   }
 }

--- a/app/controllers/TEAHubController.scala
+++ b/app/controllers/TEAHubController.scala
@@ -7,28 +7,27 @@ import play.api.mvc._
 import services.TogglService
 import services.impl.ApiGitHubService
 import services.TogglService.Project
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 
 /**
-  * This is the controller responsible for the actions related to communication between TEAHub and GitHub/Toggl.
-  * @param togglService     the service that makes the requests to Toggl
-  * @param apiGitHubService the service that makes the requests to GitHub
-  * @param cacheApi         the application cache
-  * @param executionContext the execution context for asynchronous execution of program logic
-  */
-class TEAHubController(togglService: TogglService, apiGitHubService: ApiGitHubService, cacheApi: CacheApi)
-                      (implicit executionContext: ExecutionContext) extends Controller {
+ * This is the controller responsible for the actions related to communication between TEAHub and GitHub/Toggl.
+ * @param togglService     the service that makes the requests to Toggl
+ * @param apiGitHubService the service that makes the requests to GitHub
+ * @param cacheApi         the application cache
+ * @param executionContext the execution context for asynchronous execution of program logic
+ */
+class TEAHubController(togglService: TogglService, apiGitHubService: ApiGitHubService, cacheApi: CacheApi)(implicit executionContext: ExecutionContext) extends Controller {
 
   /**
-    * Get list of Toggl projects
-    * @return A json object containing the list of Toggl projects
-    */
+   * Get list of Toggl projects
+   * @return A json object containing the list of Toggl projects
+   */
   def togglProjects: Future[List[Project]] = {
     def cacheKey(apiKey: String) = s"ProjectName.$apiKey"
 
     val togglToken = cacheApi.get[String]("togglToken") match {
       case None => "" // TODO: the token will be read from the DB in the future, right now is extracted from the cache.
-                      // Take a closer look into this later
+      // Take a closer look into this later
       case Some(token) => token
     }
 
@@ -36,9 +35,9 @@ class TEAHubController(togglService: TogglService, apiGitHubService: ApiGitHubSe
   }
 
   /**
-    * Get list of GitHub repositories
-    * @return A json object containing the list of GitHub repositories.
-    */
+   * Get list of GitHub repositories
+   * @return A json object containing the list of GitHub repositories.
+   */
   def githubRepositories = Action.async { implicit request =>
     val result: Future[List[String]] = request.session.get("oauth-token").map { token =>
       apiGitHubService.getGitHubProjects(token)

--- a/app/controllers/UIController.scala
+++ b/app/controllers/UIController.scala
@@ -4,35 +4,35 @@ import java.util.concurrent.TimeUnit
 import play.api.cache.CacheApi
 import play.api.data.Form
 import play.api.data.Forms._
-import play.api.i18n.{I18nSupport, MessagesApi}
-import play.api.mvc.{Action, Controller}
+import play.api.i18n.{ I18nSupport, MessagesApi }
+import play.api.mvc.{ Action, Controller }
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.Duration
 
 /**
-  * This controller is mainly responsible for linking the views.
-  * @param messagesApi      the messagesAPI for internationalisation.
-  * @param executionContext the execution context for asynchronous execution of program logic
-  * @param teaHubController The controller that calls the API from Github and Toggl
-  */
-class UIController(val messagesApi: MessagesApi, cacheApi: CacheApi, teaHubController: TEAHubController)
-                  (implicit executionContext: ExecutionContext) extends Controller with I18nSupport {
+ * This controller is mainly responsible for linking the views.
+ * @param messagesApi      the messagesAPI for internationalisation.
+ * @param executionContext the execution context for asynchronous execution of program logic
+ * @param teaHubController The controller that calls the API from Github and Toggl
+ */
+class UIController(val messagesApi: MessagesApi, cacheApi: CacheApi, teaHubController: TEAHubController)(implicit executionContext: ExecutionContext) extends Controller with I18nSupport {
   val togglTokenForm = Form(single("togglToken" -> text()))
   val projectName = Form(single("projectName" -> text()))
 
   def management = Action { implicit request => Ok(views.html.user_management()) }
 
-  def listPost = Action { implicit request => {
-    togglTokenForm.bindFromRequest().fold(
-      error => // Warning here because 'error' is never used
-        BadRequest(views.html.setup_projects(togglTokenForm, "An error occurred.")),
-      data => {
-        cacheApi.set("togglToken", data, Duration(1, TimeUnit.DAYS)) // TODO: in the future this will be stored on
-        // the DB
-        Ok(views.html.projects())
-      }
-    )
-  }
+  def listPost = Action { implicit request =>
+    {
+      togglTokenForm.bindFromRequest().fold(
+        error => // Warning here because 'error' is never used
+          BadRequest(views.html.setup_projects(togglTokenForm, "An error occurred.")),
+        data => {
+          cacheApi.set("togglToken", data, Duration(1, TimeUnit.DAYS)) // TODO: in the future this will be stored on
+          // the DB
+          Ok(views.html.projects())
+        }
+      )
+    }
   }
 
   def listGet = Action { implicit request =>

--- a/app/controllers/UIController.scala
+++ b/app/controllers/UIController.scala
@@ -22,17 +22,21 @@ class UIController(val messagesApi: MessagesApi, cacheApi: CacheApi, teaHubContr
 
   def management = Action { implicit request => Ok(views.html.user_management()) }
 
-  def list = Action { implicit request => {
-      togglTokenForm.bindFromRequest().fold(
-        error => // Warning here because 'error' is never used
-          BadRequest(views.html.setup_projects(togglTokenForm, "An error occurred.")),
-        data => {
-          cacheApi.set("togglToken", data, Duration(1, TimeUnit.DAYS)) // TODO: in the future this will be stored on
-                                                                       // the DB
-          Ok(views.html.projects())
-        }
-      )
-    }
+  def listPost = Action { implicit request => {
+    togglTokenForm.bindFromRequest().fold(
+      error => // Warning here because 'error' is never used
+        BadRequest(views.html.setup_projects(togglTokenForm, "An error occurred.")),
+      data => {
+        cacheApi.set("togglToken", data, Duration(1, TimeUnit.DAYS)) // TODO: in the future this will be stored on
+        // the DB
+        Ok(views.html.projects())
+      }
+    )
+  }
+  }
+
+  def listGet = Action { implicit request =>
+    Ok(views.html.projects())
   }
 
   def setup = Action { implicit request => Ok(views.html.setup_projects(togglTokenForm, "")) }

--- a/app/services/GitHubService.scala
+++ b/app/services/GitHubService.scala
@@ -1,124 +1,123 @@
 package services
 
-import play.api.libs.json.{Format, Json}
+import play.api.libs.json.{ Format, Json }
 import scala.concurrent.Future
 
 /**
-  * This is the interface of the GitHub service which returns the list of repositories that a user can
-  * access in Github.
-  */
+ * This is the interface of the GitHub service which returns the list of repositories that a user can
+ * access in Github.
+ */
 trait GitHubService {
 
   /**
-    * Get a list of projects for a certain Github account
-    * @param oauthToken Authentication token which is received from Github
-    * @return a Future List of Github repositories
-    */
+   * Get a list of projects for a certain Github account
+   * @param oauthToken Authentication token which is received from Github
+   * @return a Future List of Github repositories
+   */
   def getGitHubProjects(oauthToken: String): Future[List[String]]
 }
 
-
 /**
-  * Companion object including case class model for GitHub related entities (Owner, Permission, Repo),
-  * and Reads/Writes to convert them from/to json format.
-  */
+ * Companion object including case class model for GitHub related entities (Owner, Permission, Repo),
+ * and Reads/Writes to convert them from/to json format.
+ */
 object GitHubService {
 
   /**
-    * Model case class for the github repository owner
-    * @param login
-    * @param id
-    * @param avatar_url
-    * @param gravatar_id
-    * @param url
-    * @param html_url
-    * @param followers_url
-    * @param following_url
-    * @param gists_url
-    * @param starred_url
-    * @param subscriptions_url
-    * @param organizations_url
-    * @param repos_url
-    * @param events_url
-    * @param received_events_url
-    * @param `type`
-    * @param site_admin
-    */
+   * Model case class for the github repository owner
+   * @param login
+   * @param id
+   * @param avatar_url
+   * @param gravatar_id
+   * @param url
+   * @param html_url
+   * @param followers_url
+   * @param following_url
+   * @param gists_url
+   * @param starred_url
+   * @param subscriptions_url
+   * @param organizations_url
+   * @param repos_url
+   * @param events_url
+   * @param received_events_url
+   * @param `type`
+   * @param site_admin
+   */
   case class Owner(
-                    login: String,
-                    id: Int,
-                    avatar_url: String,
-                    gravatar_id: String,
-                    url: String,
-                    html_url: String,
-                    followers_url: String,
-                    following_url: String,
-                    gists_url: String,
-                    starred_url: String,
-                    subscriptions_url: String,
-                    organizations_url: String,
-                    repos_url: String,
-                    events_url: String,
-                    received_events_url: String,
-                    `type`:String,
-                    site_admin:Boolean
-                  )
+    login: String,
+    id: Int,
+    avatar_url: String,
+    gravatar_id: String,
+    url: String,
+    html_url: String,
+    followers_url: String,
+    following_url: String,
+    gists_url: String,
+    starred_url: String,
+    subscriptions_url: String,
+    organizations_url: String,
+    repos_url: String,
+    events_url: String,
+    received_events_url: String,
+    `type`: String,
+    site_admin: Boolean
+  )
 
   /**
-    * Model case class for the permissions applied on a certain Github repository
-    * @param admin
-    * @param push
-    * @param pull
-    */
+   * Model case class for the permissions applied on a certain Github repository
+   * @param admin
+   * @param push
+   * @param pull
+   */
   case class Permission(admin: Boolean, push: Boolean, pull: Boolean)
 
   /**
-    * Model case class for a github repository
-    * @param id
-    * @param name
-    * @param full_name
-    * @param owner
-    * @param `private`
-    * @param html_url
-    * @param description
-    * @param fork
-    * @param url
-    * @param forks_url
-    * @param keys_url
-    * @param collaborators_url
-    * @param teams_url
-    * @param hooks_url
-    * @param issue_events_url
-    * @param events_url
-    * @param assignees_url
-    * @param branches_url
-    * @param tags_url
-    * @param blobs_url
-    * @param permissions
-    */
+   * Model case class for a github repository
+   * @param id
+   * @param name
+   * @param full_name
+   * @param owner
+   * @param `private`
+   * @param html_url
+   * @param description
+   * @param fork
+   * @param url
+   * @param forks_url
+   * @param keys_url
+   * @param collaborators_url
+   * @param teams_url
+   * @param hooks_url
+   * @param issue_events_url
+   * @param events_url
+   * @param assignees_url
+   * @param branches_url
+   * @param tags_url
+   * @param blobs_url
+   * @param permissions
+   */
   case class Repo(
-                   id: Int,
-                   name:String,
-                   full_name:String,
-                   owner: Owner,
-                   `private` : Boolean,
-                   html_url :String,
-                   description: Option[String],
-                   fork: Boolean,
-                   url: String,
-                   forks_url: String,
-                   keys_url: String,
-                   collaborators_url:String,
-                   teams_url:String,
-                   hooks_url:String,
-                   issue_events_url:String,
-                   events_url:String,
-                   assignees_url:String,
-                   branches_url:String,
-                   tags_url:String,
-                   blobs_url:String,
-                   permissions: Permission
-                 )
+    id: Int,
+    name: String,
+    full_name: String,
+    owner: Owner,
+    `private`: Boolean,
+    html_url: String,
+    description: Option[String],
+    fork: Boolean,
+    url: String,
+    forks_url: String,
+    keys_url: String,
+    collaborators_url: String,
+    teams_url: String,
+    hooks_url: String,
+    issue_events_url: String,
+    events_url: String,
+    assignees_url: String,
+    branches_url: String,
+    tags_url: String,
+    blobs_url: String,
+    permissions: Permission
+  )
 
   implicit val ownerFormat: Format[Owner] = Json.format[Owner]
   implicit val permissionFormat: Format[Permission] = Json.format[Permission]

--- a/app/services/TogglService.scala
+++ b/app/services/TogglService.scala
@@ -7,66 +7,67 @@ import play.api.libs.json._
 import services.TogglService.Project
 
 /**
-  * This is the interface of the Toggl service which is supposed to get the list of projects in a workspace.
-  */
+ * This is the interface of the Toggl service which is supposed to get the list of projects in a workspace.
+ */
 trait TogglService {
 
   /**
-    * Get a list of the project names in a Toggl workspace
-    *
-    * @param ApiToken The unique API token of the Toggle user
-    * @return A Future list of projects
-    */
+   * Get a list of the project names in a Toggl workspace
+   *
+   * @param ApiToken The unique API token of the Toggle user
+   * @return A Future list of projects
+   */
   def getTogglProjects(ApiToken: String): Future[List[Project]]
   def getTogglWorkspace(ApiToken: String): Future[List[Long]]
 }
 
 /**
-  * Companion object including case class model for Toggl projects, and Reads/Writes to convert from/to json format.
-  */
+ * Companion object including case class model for Toggl projects, and Reads/Writes to convert from/to json format.
+ */
 object TogglService {
 
   /**
-    * Model case class for Toggl Project
-    *
-    * @param id             Project ID
-    * @param wid            Workspace ID, where the project belongs to
-    * @param cid            Client ID
-    * @param name           Name of the Toggl project in a specific workspace
-    * @param billable       Whether the project is billable or not
-    * @param is_private     Whether the project is accessible for only project users or for all workspace users
-    * @param active         Whether the project is archived or not
-    * @param template       Whether the project can be used as a template
-    * @param at             Indicates the time task was last updated
-    * @param created_at     Timestamp indicating when the project was created
-    * @param color          ID of the color selected for the project
-    * @param auto_estimates Whether the estimated hours are automatically calculated based on task estimations or
-    *                       manually fixed based on the value of 'estimated_hours'
-    * @param actual_hours   Hours that has been spent on the project
-    * @param hex_color      Project tag color
-    **/
+   * Model case class for Toggl Project
+   *
+   * @param id             Project ID
+   * @param wid            Workspace ID, where the project belongs to
+   * @param cid            Client ID
+   * @param name           Name of the Toggl project in a specific workspace
+   * @param billable       Whether the project is billable or not
+   * @param is_private     Whether the project is accessible for only project users or for all workspace users
+   * @param active         Whether the project is archived or not
+   * @param template       Whether the project can be used as a template
+   * @param at             Indicates the time task was last updated
+   * @param created_at     Timestamp indicating when the project was created
+   * @param color          ID of the color selected for the project
+   * @param auto_estimates Whether the estimated hours are automatically calculated based on task estimations or
+   *                       manually fixed based on the value of 'estimated_hours'
+   * @param actual_hours   Hours that has been spent on the project
+   * @param hex_color      Project tag color
+   */
   case class Project(id: Long, wid: Long, cid: Long, name: String,
-                     billable: Boolean, is_private: Boolean, active: Boolean,
-                     template: Boolean, at: DateTime, created_at: DateTime,
-                     color: String, auto_estimates: Boolean, actual_hours: Int, hex_color: String)
+    billable: Boolean, is_private: Boolean, active: Boolean,
+    template: Boolean, at: DateTime, created_at: DateTime,
+    color: String, auto_estimates: Boolean, actual_hours: Int, hex_color: String)
 
-
-  case class Workspace(id: Long,
-                       name: String,
-                       profile: Int,
-                       premium: Boolean,
-                       admin: Boolean,
-                       default_currency: String,
-                       only_admins_may_create_projects: Boolean,
-                       only_admins_see_billable_rates: Boolean,
-                       only_admins_see_team_dashboard: Boolean,
-                       projects_billable_by_default: Boolean,
-                       rounding: Int,
-                       rounding_minutes: Int,
-                       at: DateTime,
-                       logo_url: String,
-                       ical_url: String,
-                       ical_enabled: Boolean)
+  case class Workspace(
+    id: Long,
+    name: String,
+    profile: Int,
+    premium: Boolean,
+    admin: Boolean,
+    default_currency: String,
+    only_admins_may_create_projects: Boolean,
+    only_admins_see_billable_rates: Boolean,
+    only_admins_see_team_dashboard: Boolean,
+    projects_billable_by_default: Boolean,
+    rounding: Int,
+    rounding_minutes: Int,
+    at: DateTime,
+    logo_url: String,
+    ical_url: String,
+    ical_enabled: Boolean
+  )
 
   implicit val dateReads = Reads.jodaDateReads("yyyy-MM-dd'T'HH:mm:ssZZ")
   implicit val dateWrites = Writes.jodaDateWrites("yyyy-MM-dd'T'HH:mm:ss")

--- a/app/services/impl/ApiGitHubService.scala
+++ b/app/services/impl/ApiGitHubService.scala
@@ -7,23 +7,23 @@ import services.GitHubService
 import scala.concurrent.ExecutionContext
 
 /**
-  * Implementation of [[GitHubService]]
-  * @param ws the WS client
-  * @param ec the execution context for asynchronous execution of program logic
-  */
-class ApiGitHubService(ws: WSClient) (implicit val ec: ExecutionContext) extends GitHubService {
+ * Implementation of [[GitHubService]]
+ * @param ws the WS client
+ * @param ec the execution context for asynchronous execution of program logic
+ */
+class ApiGitHubService(ws: WSClient)(implicit val ec: ExecutionContext) extends GitHubService {
 
   /**
-    * Get the list of GitHub projects
-    * @param oauthToken the OAuth token to use in order to access a certain repository
-    * @return a Future List of Github repositories
-    */
+   * Get the list of GitHub projects
+   * @param oauthToken the OAuth token to use in order to access a certain repository
+   * @return a Future List of Github repositories
+   */
   override def getGitHubProjects(oauthToken: String) = {
     val reposURL = "https://api.github.com/user/repos"
 
     ws.url(reposURL)
       .withHeaders(HeaderNames.AUTHORIZATION -> s"token ${oauthToken}").get.map { response =>
-      response.json.as[List[Repo]].map(x => x.name)
-    }
+        response.json.as[List[Repo]].map(x => x.name)
+      }
   }
 }

--- a/app/services/impl/ApiOAuthGitHubService.scala
+++ b/app/services/impl/ApiOAuthGitHubService.scala
@@ -2,17 +2,17 @@ package services.impl
 
 import java.util.UUID
 import com.typesafe.config.Config
-import play.api.http.{HeaderNames, MimeTypes}
+import play.api.http.{ HeaderNames, MimeTypes }
 import play.api.libs.ws.WSClient
 import play.api.mvc.Results
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 
 /**
-  * Service providing helper functions to OAuthGitHubController
-  * @param config configuration of the application
-  * @param ws the WS client
-  * @param executionContext the execution context for asynchronous execution of program logic
-  */
+ * Service providing helper functions to OAuthGitHubController
+ * @param config configuration of the application
+ * @param ws the WS client
+ * @param executionContext the execution context for asynchronous execution of program logic
+ */
 class ApiOAuthGitHubService(config: Config, ws: WSClient)(implicit executionContext: ExecutionContext) {
 
   val baseUrl = config.getString("github.oauth.url")
@@ -22,30 +22,33 @@ class ApiOAuthGitHubService(config: Config, ws: WSClient)(implicit executionCont
   val scope = config.getString("github.client.scope")
 
   /**
-    * Create the url with the required parameters to connect initiate OAuth authentication between TEAHub and GitHub.
-    * @return a tuple containing the complete URL and the `state` parameter used in the request.
-    */
+   * Create the url with the required parameters to connect initiate OAuth authentication between TEAHub and GitHub.
+   * @return a tuple containing the complete URL and the `state` parameter used in the request.
+   */
   def oauthGitHubConnectUrl: (String, String) = {
     val state = UUID.randomUUID().toString
     (baseUrl.format(githubClientId, githubRedirectURL, scope, state), state)
   }
 
   /**
-    * Get the access token in order to access GitHub.
-    * @param code is the code received when requesting access to GitHub.
-    * @return the access token to authenticate access to GitHub
-    */
+   * Get the access token in order to access GitHub.
+   * @param code is the code received when requesting access to GitHub.
+   * @return the access token to authenticate access to GitHub
+   */
   def getToken(code: String): Future[String] = {
     val tokenResponse = ws.url("https://github.com/login/oauth/access_token").
-      withQueryString("client_id" -> githubClientId,
+      withQueryString(
+        "client_id" -> githubClientId,
         "client_secret" -> githubClientSecret,
-        "code" -> code).
-      withHeaders(HeaderNames.ACCEPT -> MimeTypes.JSON).
-      post(Results.EmptyContent())
+        "code" -> code
+      ).
+        withHeaders(HeaderNames.ACCEPT -> MimeTypes.JSON).
+        post(Results.EmptyContent())
 
-    tokenResponse.flatMap { response => (response.json \ "access_token").asOpt[String].fold(Future.failed[String](
-      new IllegalStateException("Sod off!")
-    )){ accessToken =>
+    tokenResponse.flatMap { response =>
+      (response.json \ "access_token").asOpt[String].fold(Future.failed[String](
+        new IllegalStateException("Sod off!")
+      )) { accessToken =>
         Future.successful(accessToken)
       }
     }

--- a/app/services/impl/ApiTogglService.scala
+++ b/app/services/impl/ApiTogglService.scala
@@ -1,47 +1,47 @@
 package services.impl
 
 import services.TogglService
-import services.TogglService.{Project, Workspace}
+import services.TogglService.{ Project, Workspace }
 import play.api.libs.ws.WSClient
 import play.api.libs.ws.WSAuthScheme.BASIC
 import play.api.libs.json._
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 
 /**
-  * Implementation of [[TogglService]]
-  * @param ws the WS client
-  * @param ec the execution context for asynchronous execution of program logic
-  */
+ * Implementation of [[TogglService]]
+ * @param ws the WS client
+ * @param ec the execution context for asynchronous execution of program logic
+ */
 class ApiTogglService(ws: WSClient)(implicit val ec: ExecutionContext) extends TogglService {
 
   /**
-    * Request Toggl the list of all projects inside the specified workspace
-    * @param apiToken to access a certain Toggl workspace
-    * @return the list of all Toggle projects in the workspace
-    */
+   * Request Toggl the list of all projects inside the specified workspace
+   * @param apiToken to access a certain Toggl workspace
+   * @return the list of all Toggle projects in the workspace
+   */
   override def getTogglProjects(apiToken: String): Future[List[Project]] = {
     for {
       workspaceID <- getTogglWorkspace(apiToken)
       request <- ws.url(s"https://www.toggl.com/api/v8/workspaces/" + workspaceID.head + "/projects")
         .withHeaders("Content-Type" -> "application/Json")
         .withAuth(apiToken, "api_token", BASIC).get().map { response =>
-        val bodyJSValue: JsValue = Json.parse(response.body)
-        val validateBody = bodyJSValue.validate[List[Project]]
-        validateBody match {
-          case JsSuccess(projectList: List[Project], _) => projectList
-          case JsError(_) => List.empty
+          val bodyJSValue: JsValue = Json.parse(response.body)
+          val validateBody = bodyJSValue.validate[List[Project]]
+          validateBody match {
+            case JsSuccess(projectList: List[Project], _) => projectList
+            case JsError(_) => List.empty
+          }
         }
-      }
 
     } yield request
   }
 
   /**
-    * Gets the workspace ID
-    *
-    * @param apiToken API token provided by the user
-    * @return List that always contains a single element: the workspace ID
-    */
+   * Gets the workspace ID
+   *
+   * @param apiToken API token provided by the user
+   * @return List that always contains a single element: the workspace ID
+   */
   override def getTogglWorkspace(apiToken: String): Future[List[Long]] = {
     val request = ws.url("https://www.toggl.com/api/v8/workspaces")
       .withHeaders("Content-Type" -> "application/Json")
@@ -54,7 +54,7 @@ class ApiTogglService(ws: WSClient)(implicit val ec: ExecutionContext) extends T
         case JsSuccess(workspaceList: List[Workspace], _) =>
           workspaceList.map(_.id)
         case JsError(_) => // TODO: The value of the api-token should be read from DB or we should show an error page to
-                           // the user for entering wrong api-toke
+          // the user for entering wrong api-toke
           List.empty
       }
     }

--- a/app/services/impl/ApiTogglService.scala
+++ b/app/services/impl/ApiTogglService.scala
@@ -27,7 +27,6 @@ class ApiTogglService(ws: WSClient)(implicit val ec: ExecutionContext) extends T
         .withAuth(apiToken, "api_token", BASIC).get().map { response =>
         val bodyJSValue: JsValue = Json.parse(response.body)
         val validateBody = bodyJSValue.validate[List[Project]]
-        ws.close()
         validateBody match {
           case JsSuccess(projectList: List[Project], _) => projectList
           case JsError(_) => List.empty

--- a/app/views/setup_projects.scala.html
+++ b/app/views/setup_projects.scala.html
@@ -17,7 +17,7 @@
                         <br/>
                         @msg
                         <br/>
-                        @b3.form(routes.UIController.list) {
+                        @b3.form(routes.UIController.listPost) {
                             @b3.text(togglTokenForm("togglToken"), '_label -> "token", 'placeholder -> "Please insert Toggle token")
                             <input class="btn btn-primary" type="submit" value="Next"/>
                         }

--- a/conf/routes
+++ b/conf/routes
@@ -1,5 +1,6 @@
 GET     /                       controllers.OAuthGitHubController.login
-POST    /projects               controllers.UIController.list
+POST    /projects               controllers.UIController.listPost
+GET     /projects               controllers.UIController.listGet
 GET     /projects_setup         controllers.UIController.setup
 GET     /project_details        controllers.UIController.details
 GET     /profile                controllers.UIController.profile


### PR DESCRIPTION
Fix wsClient:
- Create a wsClient in AppLoader and pass it to the required services.
- Close wsClient when the application closes.
- Avoid closing ws during the execution.

Fix /GET in /projects
- Add listPost/listGet methods to routes to differentiate access to the page from POST/GET
- Propagate changes accordingly.